### PR TITLE
xfce4-power-manager: Don't use /run/current-system/sw/bin in org.free…

### DIFF
--- a/pkgs/by-name/xf/xfce4-power-manager/package.nix
+++ b/pkgs/by-name/xf/xfce4-power-manager/package.nix
@@ -56,12 +56,15 @@ stdenv.mkDerivation (finalAttrs: {
   # using /run/current-system/sw/bin instead of nix store path prevents polkit permission errors on
   # rebuild.  See https://github.com/NixOS/nixpkgs/issues/77485
   postPatch = ''
-    substituteInPlace src/org.xfce.power.policy.in.in --replace-fail "@sbindir@" "/run/current-system/sw/bin"
     substituteInPlace common/xfpm-brightness-polkit.c --replace-fail "SBINDIR" "\"/run/current-system/sw/bin\""
     substituteInPlace src/xfpm-suspend.c --replace-fail "SBINDIR" "\"/run/current-system/sw/bin\""
   '';
 
-  configureFlags = [ "--enable-maintainer-mode" ];
+  configureFlags = [
+    "--enable-maintainer-mode"
+    "--sbindir=\${out}/bin"
+  ];
+
   enableParallelBuilding = true;
 
   passthru.updateScript = gitUpdater {


### PR DESCRIPTION
…desktop.policykit.exec.path

So polkit popup no longer appears when adjusting brightness with polkit 127.

To ensure the xpm's realpath matches org.freedesktop.policykit.exec.path after `nixos-rebuild switch` (where xpm won't be restarted), we still need to keep the other two substitutions.

ref: https://github.com/polkit-org/polkit/commit/9aa43e089d870a8ee695e625237c5b731b250678
ref: 6a2999310e4f5d4bfdec15d1aed54f98096fba9d


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
